### PR TITLE
Task/refactor pipelines and scripting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
       id: ps_tests
       if: steps.manifest_build.conclusion == 'success'
       run: |
-        make pstestsbuild
+        make pstests
 
   macosbuild:
     name: "MacOS Build"
@@ -107,7 +107,7 @@ jobs:
       id: ps_tests
       if: steps.manifest_build.conclusion == 'success'
       run: |
-        make pstestsbuild
+        make pstests
 
   linuxbuild:
     name: "Linux Build & Publish"
@@ -161,10 +161,79 @@ jobs:
       id: ps_tests
       if: steps.manifest_build.conclusion == 'success'
       run: |
-        make pstestsbuild
+        make pstests
 
     - name: publish module
       id: publish_module
-      if: steps.ps_tests.conclusion == 'success'
+      if: ${{ github.ref == 'refs/heads/main' && steps.ps_tests.conclusion == 'success' }}
       run: |
         make publishmodule psNuGetSourceName=PSGallery psNuGetApiKey=${{ secrets.PSGALLERY_KEY }}
+
+  windowsinstall:
+    name: "Windows Install & Test"
+    needs: linuxbuild
+    if: ${{ github.ref == 'refs/heads/main' && success() }}
+    runs-on: windows-latest
+
+    steps:
+    - name: Checkout code
+      id: checkout
+      uses: actions/checkout@v2
+
+    - name: install module
+      id: ps_tests
+      if: steps.checkout.conclusion == 'success'
+      run: |
+        make installmodule psNuGetSourceName=PSGallery
+
+    - name: run powershell tests
+      id: ps_tests
+      if: steps.manifest_build.conclusion == 'success'
+      run: |
+        make pstestspostinstall psNuGetSourceName=PSGallery
+
+  macosinstall:
+    name: "MacOS Install & Test"
+    needs: windowsinstall
+    if: ${{ github.ref == 'refs/heads/main' && success() }}
+    runs-on: macos-latest
+
+    steps:
+    - name: Checkout code
+      id: checkout
+      uses: actions/checkout@v2
+
+    - name: install module
+      id: ps_tests
+      if: steps.checkout.conclusion == 'success'
+      run: |
+        make installmodule psNuGetSourceName=PSGallery
+
+    - name: run powershell tests
+      id: ps_tests
+      if: steps.manifest_build.conclusion == 'success'
+      run: |
+        make pstestspostinstall psNuGetSourceName=PSGallery
+
+  linuxinstall:
+    name: "Linux Install & Test"
+    needs: macosinstall
+    if: ${{ github.ref == 'refs/heads/main' && success() }}
+    runs-on: linux-latest
+
+    steps:
+    - name: Checkout code
+      id: checkout
+      uses: actions/checkout@v2
+
+    - name: install module
+      id: ps_tests
+      if: steps.checkout.conclusion == 'success'
+      run: |
+        make installmodule psNuGetSourceName=PSGallery
+
+    - name: run powershell tests
+      id: ps_tests
+      if: steps.manifest_build.conclusion == 'success'
+      run: |
+        make pstestspostinstall psNuGetSourceName=PSGallery

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,14 +181,14 @@ jobs:
       uses: actions/checkout@v2
 
     - name: install module
-      id: ps_tests
+      id: install_module
       if: steps.checkout.conclusion == 'success'
       run: |
         make installmodule psNuGetSourceName=PSGallery
 
     - name: run powershell tests
-      id: ps_tests
-      if: steps.manifest_build.conclusion == 'success'
+      id: ps_tests_install
+      if: steps.install_module.conclusion == 'success'
       run: |
         make pstestspostinstall psNuGetSourceName=PSGallery
 
@@ -204,14 +204,14 @@ jobs:
       uses: actions/checkout@v2
 
     - name: install module
-      id: ps_tests
+      id: install_module
       if: steps.checkout.conclusion == 'success'
       run: |
         make installmodule psNuGetSourceName=PSGallery
 
     - name: run powershell tests
-      id: ps_tests
-      if: steps.manifest_build.conclusion == 'success'
+      id: ps_tests_install
+      if: steps.install_module.conclusion == 'success'
       run: |
         make pstestspostinstall psNuGetSourceName=PSGallery
 
@@ -227,13 +227,13 @@ jobs:
       uses: actions/checkout@v2
 
     - name: install module
-      id: ps_tests
+      id: install_module
       if: steps.checkout.conclusion == 'success'
       run: |
         make installmodule psNuGetSourceName=PSGallery
 
     - name: run powershell tests
-      id: ps_tests
-      if: steps.manifest_build.conclusion == 'success'
+      id: ps_tests_install
+      if: steps.install_module.conclusion == 'success'
       run: |
         make pstestspostinstall psNuGetSourceName=PSGallery

--- a/Scripts/CreateManifest.ps1
+++ b/Scripts/CreateManifest.ps1
@@ -22,7 +22,11 @@ if ((Test-Path -Path $buildDir)) {
 
 New-Item -ItemType Directory -Path $buildDir | Out-Null;
 
-Copy-Item -Path "$rootDir$($sep)src$($sep)DoCli" -Destination "$buildDir$($sep)DoCli" -Recurse -Force;
+New-Item -ItemType Directory -Path "$buildDir$($sep)DoCli" | Out-Null;
+
+Copy-Item -Path "$rootDir$($sep)src$($sep)DoCli$($sep)Functions" -Destination "$buildDir$($sep)DoCli$($sep)Functions" -Recurse -Force;
+
+Copy-Item -Path "$rootDir$($sep)src$($sep)DoCli$($sep)Objects" -Destination "$buildDir$($sep)DoCli$($sep)Objects" -Recurse -Force;
 
 Copy-Item -Path "$rootDir$($sep)Scripts$($sep)ModuleDependenciesInstall.ps1" -Destination "$buildDir$($sep)ModuleDependenciesInstall.ps1" -Force;
 
@@ -36,7 +40,6 @@ $items += Get-ChildItem "$baseDir$($sep)Objects$($sep)Environment" -Recurse;
 $items += Get-ChildItem "$baseDir$($sep)Objects$($sep)Mappers" -Recurse;
 $items += Get-ChildItem "$baseDir$($sep)Objects$($sep)Modules" -Recurse;
 $items += Get-ChildItem "$baseDir$($sep)Objects$($sep)Processing" -Recurse;
-$items += Get-ChildItem "$baseDir$($sep)Objects$($sep)Testing" -Recurse;
 $items += Get-ChildItem "$baseDir$($sep)Objects$($sep)Validators" -Recurse;
 $items += Get-ChildItem "$baseDir$($sep)Objects$($sep)Services$($sep)ApplicationServiceContainer.psm1";
 $items += Get-ChildItem "$baseDir$($sep)Objects$($sep)CLI" -Recurse;

--- a/Scripts/InstallModule.ps1
+++ b/Scripts/InstallModule.ps1
@@ -1,0 +1,15 @@
+using module ".\lib\VersionCalculator.psm1";
+
+param (
+    [Parameter(Mandatory=$true)] [ValidateNotNullOrEmpty()] [string] $psNuGetSourceName
+)
+
+$ErrorActionPreference = "Stop";
+
+[string] $version = [VersionCalculator]::GetLatest($psNuGetSourceName);
+
+Write-Host "Latest PSDoFramework version on the repository $($psNuGetSourceName): $version";
+
+Install-Module -Name "PSDoFramework" -RequiredVersion $version -Repository $psNuGetSourceName -Force;
+
+Write-Host "Installed PSDoFramework version $version from the repository: $($psNuGetSourceName)";

--- a/Scripts/LocalBuild.ps1
+++ b/Scripts/LocalBuild.ps1
@@ -18,18 +18,13 @@ if (!$skipTests) {
 make createmanifest;
 
 if (!$skipTests) {
-    make pstestsbuild;
+    make pstests;
 }
 
 make publishmodule psNuGetSourceName=$psNuGetSourceName;
 
-[PSCustomObject] $module = Find-Module -Name "PSDoFramework" -Repository $psNuGetSourceName -ErrorAction SilentlyContinue;
+make installmodule;
 
-[string] $version = $module.Version;
-
-if (Get-Module -ListAvailable -Name "PSDoFramework") {
-    Update-Module -Name "PSDoFramework" -Force -Verbose;
-}
-else {
-    Install-Module -Name "PSDoFramework" -Repository $psNuGetSourceName -Force -Verbose;
+if (!$skipTests) {
+    make pstestspostinstall;
 }

--- a/Scripts/ModuleDependenciesInstall.ps1
+++ b/Scripts/ModuleDependenciesInstall.ps1
@@ -12,11 +12,11 @@ foreach ($moduleName in $requiredModules.Keys) {
 
     [object[]] $moduleJson = Get-Module -ListAvailable -Name $moduleName | select-object Version;
 
-    [PSCustomObject] $version = ($moduleJson | Where-Object {
+    [PSCustomObject] $capturedVersion = ($moduleJson | Where-Object {
         return $_.Version -eq $moduleVersion;
     });
 
-    if ($null -eq $version) {
+    if ($null -eq $capturedVersion) {
         Install-Module -Name $moduleName -RequiredVersion $moduleVersion -Force -Scope CurrentUser -SkipPublisherCheck;
     }
 }

--- a/Scripts/lib/VersionCalculator.psm1
+++ b/Scripts/lib/VersionCalculator.psm1
@@ -14,4 +14,16 @@ class VersionCalculator {
 
         return $version;
     }
+
+    static [string] GetLatest([string] $psNuGetSourceName) {
+        [PSCustomObject] $module = Find-Module -Name "PSDoFramework" -Repository $psNuGetSourceName -ErrorAction SilentlyContinue;
+
+        [string] $version = "1.1.0";
+
+        if ($null -ne $module) {
+            return $module.Version;
+        }
+
+        return $version;
+    }
 }

--- a/makefile
+++ b/makefile
@@ -20,14 +20,10 @@ dotnettest:
 
 # DoFramework PowerShell Testing
 pstests:
-	pwsh -ExecutionPolicy Bypass -Command " \
-		Import-Module .\Build\PSDoFramework\PSDoFramework.psd1 -Force -verbose -ErrorAction Stop; \
-		& '${CURDIR}/Scripts/PSTestOrchestrator.ps1';"
-
-pstestsbuild:
-	pwsh -ExecutionPolicy Bypass -Command " \
-		Import-Module .\Build\PSDoFramework\PSDoFramework.psd1 -Force -verbose -ErrorAction Stop; \
-		& '${CURDIR}/Scripts/PSTestOrchestrator.ps1' -isBuildRun;"
+	pwsh -ExecutionPolicy Bypass -Command "& '${CURDIR}/Scripts/PSTestOrchestrator.ps1';"
+	
+pstestspostinstall:
+	pwsh -ExecutionPolicy Bypass -Command "& '${CURDIR}/Scripts/PSTestOrchestrator.ps1' -useLatest -psNuGetSourceName $(psNuGetSourceName);"
 
 # Module deployment
 createmanifest:
@@ -35,6 +31,9 @@ createmanifest:
 
 publishmodule:
 	pwsh -ExecutionPolicy Bypass -Command "& '${CURDIR}/Scripts/PublishPowerShellModule.ps1' -psNuGetSourceName $(psNuGetSourceName) -psNuGetApiKey $(psNuGetApiKey)"
+
+installmodule:
+	pwsh -ExecutionPolicy Bypass -Command "& '${CURDIR}/Scripts/InstallModule.ps1' -psNuGetSourceName $(psNuGetSourceName)"
 
 # Local Development support features
 createlocalnugetsource:


### PR DESCRIPTION
House keeping & build improvements:

1. PowerShell test files no longer included with published module
2. Makefile simplified (reduction in duplicated make targets)
3. Local build and pipelines modified so that the published module is installed on the running OS and is then proven out against the Component/sample tests
4. Pipeline only publishes module when executed on main
5. Some simplifications to orchestrating build scripts

Test evidence:

Pipeline run: https://github.com/andy192700/psdoframework/actions/runs/12990431106

Local build screenshots:

![image](https://github.com/user-attachments/assets/7fd75003-a0b3-4f94-b59e-ef68406b2f8c)
![image](https://github.com/user-attachments/assets/3bd814ee-cfa7-498d-a2ca-2703be8b6f60)
![image](https://github.com/user-attachments/assets/b10dd873-e9d8-4a72-bef6-3c039b0e6760)
![image](https://github.com/user-attachments/assets/0d51fe1e-b779-4ee9-80c3-743341c1b90a)
![image](https://github.com/user-attachments/assets/c93a2321-e59d-4c05-8877-6c9a04b6f86a)
![image](https://github.com/user-attachments/assets/0470cb1a-e655-4ff7-a688-7f3f8f859eac)

