### PR TITLE
decoupled environment class and envrionment validation

### DIFF
--- a/src/DoCli/Tests/Unit/Objects/Testing/ProcessTestRunnerTests.ps1
+++ b/src/DoCli/Tests/Unit/Objects/Testing/ProcessTestRunnerTests.ps1
@@ -185,7 +185,6 @@ Describe 'ProcessTestRunnerTests' {
 
         [DoFramework.Environment.Environment] $env = [DoFramework.Environment.Environment]::new(
             $mockReadProcessLocation.Instance,
-            $mockFileSystem.Instance,
             $mockProjectProvider.Instance
         );
 

--- a/src/DoFramework/DoFramework/Environment/Environment.cs
+++ b/src/DoFramework/DoFramework/Environment/Environment.cs
@@ -35,7 +35,6 @@ public class Environment : IEnvironment
     public static char Separator { get; } = Path.DirectorySeparatorChar;
 
     private readonly IReadProcessLocation _readProcessLocation;
-    private readonly IFileManager _FileManager;
     private readonly ISimpleDataProvider<ProjectContents> _projectContentsProvider;
 
     /// <summary>
@@ -46,41 +45,16 @@ public class Environment : IEnvironment
     /// <param name="projectContentsProvider">An instance of <see cref="ISimpleDataProvider{ProjectContents}"/> to provide project contents.</param>
     public Environment(
         IReadProcessLocation readProcessLocation,
-        IFileManager fileManager,
         ISimpleDataProvider<ProjectContents> projectContentsProvider)
     {
         _readProcessLocation = readProcessLocation;
-        _FileManager = fileManager;
         _projectContentsProvider = projectContentsProvider;
 
         HomeDir = _readProcessLocation.Read();
-
-        ValidateEnvironment();
 
         var contents = _projectContentsProvider.Provide();
         ProcessesDir = $"{HomeDir}{Separator}{contents.Name}{Separator}Processes";
         TestsDir = $"{HomeDir}{Separator}{contents.Name}{Separator}Tests";
         ModuleDir = $"{HomeDir}{Separator}{contents.Name}{Separator}Modules";
-    }
-
-    /// <summary>
-    /// Checks if the environment is valid by verifying the existence of a specific file.
-    /// </summary>
-    /// <returns>True if the environment is valid; otherwise, false.</returns>
-    public bool CheckEnvironment()
-    {
-        return _FileManager.FileExists($"{HomeDir}{Separator}do.json");
-    }
-
-    /// <summary>
-    /// Validates the environment by checking for the existence of a required project file.
-    /// </summary>
-    /// <exception cref="Exception">Thrown when the required project file is not found.</exception>
-    public void ValidateEnvironment()
-    {
-        if (!CheckEnvironment())
-        {
-            throw new Exception("Error - Do project not found.");
-        }
     }
 }

--- a/src/DoFramework/DoFramework/Environment/IEnvironment.cs
+++ b/src/DoFramework/DoFramework/Environment/IEnvironment.cs
@@ -24,15 +24,4 @@ public interface IEnvironment
     /// Gets or sets the modules directory within the environment.
     /// </summary>
     string ModuleDir { get; set; }
-
-    /// <summary>
-    /// Checks if the environment is valid by verifying the existence of a specific file.
-    /// </summary>
-    /// <returns>True if the environment is valid; otherwise, false.</returns>
-    bool CheckEnvironment();
-
-    /// <summary>
-    /// Validates the environment by checking for the existence of a required project file.
-    /// </summary>
-    void ValidateEnvironment();
 }

--- a/src/DoFramework/DoFramework/Services/ServiceContainerExtensions.cs
+++ b/src/DoFramework/DoFramework/Services/ServiceContainerExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using DoFramework.CLI;
-using DoFramework.Data;
-using DoFramework.Environment;
+using DoFramework.FileSystem;
 using DoFramework.Logging;
 using DoFramework.Processing;
 
@@ -18,9 +17,14 @@ public static class ServiceContainerExtensions
     /// <returns>The service container with the validated environment.</returns>
     public static IServiceContainer CheckEnvironment(this IServiceContainer container)
     {
-        var environment = container.GetService<IEnvironment>();
+        var fileManager = container.GetService<IFileManager>();
 
-        environment!.ValidateEnvironment();
+        var processLocationReader = container.GetService<IReadProcessLocation>();
+
+        if (!fileManager.FileExists($"{processLocationReader.Read()}{Environment.Environment.Separator}do.json"))
+        {
+            throw new Exception("Could not find do.json.");
+        }
 
         return container;
     }

--- a/src/DoFramework/DoFrameworkTests/Environment/EnvironmentTests.cs
+++ b/src/DoFramework/DoFrameworkTests/Environment/EnvironmentTests.cs
@@ -6,8 +6,6 @@ using DoFramework.Mappers;
 using FluentAssertions;
 using Moq;
 using Newtonsoft.Json;
-using System;
-using System.IO;
 
 namespace DoFrameworkTests.Environment;
 
@@ -41,102 +39,12 @@ public class EnvironmentTests
 
         var sut = new DoFramework.Environment.Environment(
             readProcessLocation.Object, 
-            fileManager.Object,
             contentsProvider);
 
         var homeDir = readProcessLocation.Object.Read();
         var baseDir = $"{homeDir}{DoFramework.Environment.Environment.Separator}{projectContentsStorage.Name}{DoFramework.Environment.Environment.Separator}";
 
         // Assert
-        sut.HomeDir.Should().NotBeNull();
-        sut.HomeDir.Should().Be(homeDir);
-        sut.ProcessesDir.Should().NotBeNull();
-        sut.ProcessesDir.Should().Be($"{baseDir}Processes");
-        sut.TestsDir.Should().NotBeNull();
-        sut.TestsDir.Should().Be($"{baseDir}Tests");
-        sut.ModuleDir.Should().NotBeNull();
-        sut.ModuleDir.Should().Be($"{baseDir}Modules");
-    }
-
-    [Theory]
-    [InlineAutoMoqData]
-    public void Environment_DoesNotValidateEnvironment(
-        [Frozen] Mock<IReadProcessLocation> readProcessLocation,
-        [Frozen] Mock<IFileManager> fileManager,
-        ProjectContentsStorage projectContentsStorage)
-    {
-        // Arrange
-        var osSanitise = new Mock<IOSSanitise>();
-        var jsonConverter = new DoFramework.Data.JsonConverter();
-        var processDescriptorMapper = new ProcessDescriptorMapper(osSanitise.Object);
-        var moduleDescriptorMapper = new ModuleDescriptorMapper(osSanitise.Object);
-        var testDescriptorMapper = new TestDescriptorMapper(osSanitise.Object);
-        var contentsMapper = new ReadProjectContentsMapper(processDescriptorMapper, moduleDescriptorMapper, testDescriptorMapper, osSanitise.Object);
-        var contentsProvider = new ReadProjectContents(contentsMapper, readProcessLocation.Object, fileManager.Object, jsonConverter);
-
-        string jsonString = JsonConvert.SerializeObject(projectContentsStorage, Formatting.Indented);
-
-        fileManager.Setup(x => x.ReadAllText(It.IsAny<string>())).Returns(jsonString);
-
-        fileManager.Setup(x => x.FileExists(It.IsAny<string>())).Returns(false);
-
-        readProcessLocation.Setup(x => x.Read()).Returns(System.Environment.CurrentDirectory);
-
-        var homeDir = readProcessLocation.Object.Read();
-
-        // Act
-        var func = () => new DoFramework.Environment.Environment(
-            readProcessLocation.Object,
-            fileManager.Object,
-            contentsProvider);
-
-        // Assert
-        func.Should().Throw<Exception>().WithMessage("Error - Do project not found.");
-    }
-
-    [Theory]
-    [InlineAutoMoqData]
-    public void Environment_ValidateEnvironment(
-        [Frozen] Mock<IReadProcessLocation> readProcessLocation,
-        [Frozen] Mock<IFileManager> fileManager,
-        ProjectContentsStorage projectContentsStorage,
-        string path)
-    {
-        // Arrange
-        var jsonConverter = new DoFramework.Data.JsonConverter();
-
-        var osSanitise = new Mock<IOSSanitise>();
-
-        osSanitise.Setup(x => x.Sanitise(It.IsAny<string>())).Returns(path);
-
-        var processDescriptorMapper = new ProcessDescriptorMapper(osSanitise.Object);
-        var moduleDescriptorMapper = new ModuleDescriptorMapper(osSanitise.Object);
-        var testDescriptorMapper = new TestDescriptorMapper(osSanitise.Object);
-        var contentsMapper = new ReadProjectContentsMapper(processDescriptorMapper, moduleDescriptorMapper, testDescriptorMapper, osSanitise.Object);
-        var contentsProvider = new ReadProjectContents(contentsMapper, readProcessLocation.Object, fileManager.Object, jsonConverter);
-
-        string jsonString = JsonConvert.SerializeObject(projectContentsStorage, Formatting.Indented);
-
-        fileManager.Setup(x => x.ReadAllText(It.IsAny<string>())).Returns(jsonString);
-
-        fileManager.Setup(x => x.FileExists(It.IsAny<string>())).Returns(true);
-
-        readProcessLocation.Setup(x => x.Read()).Returns(System.Environment.CurrentDirectory);
-
-        var sut = new DoFramework.Environment.Environment(
-            readProcessLocation.Object,
-            fileManager.Object,
-            contentsProvider);
-
-        var homeDir = readProcessLocation.Object.Read();
-        var baseDir = $"{homeDir}{DoFramework.Environment.Environment.Separator}{projectContentsStorage.Name}{DoFramework.Environment.Environment.Separator}";
-
-        // Act
-        var func = () => sut.ValidateEnvironment();
-
-        // Assert
-        func.Should().NotThrow();
-
         sut.HomeDir.Should().NotBeNull();
         sut.HomeDir.Should().Be(homeDir);
         sut.ProcessesDir.Should().NotBeNull();

--- a/src/DoFramework/DoFrameworkTests/Services/ServiceContainerExtensionsTests.cs
+++ b/src/DoFramework/DoFrameworkTests/Services/ServiceContainerExtensionsTests.cs
@@ -6,6 +6,8 @@ using DoFramework.Processing;
 using DoFramework.Services;
 using FluentAssertions;
 using Moq;
+using DoFramework.FileSystem;
+using System.Net.Http.Headers;
 
 namespace DoFrameworkTests.Services;
 
@@ -17,11 +19,11 @@ public class ServiceContainerExtensionsTests
         // Arrange
         var sut = new ServiceContainer();
 
-        sut.RegisterService<IEnvironment, TestEnvironment>();
-
+        sut.RegisterService<IFileManager, PassingFileManager>();
+        sut.RegisterService<IReadProcessLocation, TestLocationReader>();
 
         // Act
-        var func = ()=> sut.CheckEnvironment();
+        var func = () => sut.CheckEnvironment();
 
         // Assert
         func.Should().NotThrow();
@@ -33,26 +35,14 @@ public class ServiceContainerExtensionsTests
         // Arrange
         var sut = new ServiceContainer();
 
-        sut.RegisterService<IEnvironment, TestThrowingEnvironment>();
+        sut.RegisterService<IFileManager, FailingFileManager>();
+        sut.RegisterService<IReadProcessLocation, TestLocationReader>();
 
         // Act
         var func = () => sut.CheckEnvironment();
 
         // Assert
-        func.Should().Throw<Exception>().WithMessage("Test Exception.");
-    }
-
-    [Fact]
-    public void ServiceContainerExtensions_EnvironmentNotRegisteredResolutionFailure()
-    {
-        // Arrange
-        var sut = new ServiceContainer();
-
-        // Act
-        var func = () => sut.CheckEnvironment();
-
-        // Assert
-        func.Should().Throw<Exception>().WithMessage($"Service of Type '{typeof(IEnvironment)}' could not be resolved.");
+        func.Should().Throw<Exception>().WithMessage("Could not find do.json.");
     }
 
     [Theory]
@@ -140,5 +130,109 @@ public class TestConsumeEnvFiles : IConsumeEnvFiles
     public void Consume() 
     {
         Called = true;
+    }
+}
+
+public class TestLocationReader : IReadProcessLocation
+{
+    public string Read()
+    {
+        return string.Empty;
+    }
+}
+
+public class PassingFileManager : IFileManager
+{
+    public void CreateParentDirectory(string path)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void DeleteFile(string path)
+    {
+        throw new NotImplementedException();
+    }
+
+    public bool FileExists(string path)
+    {
+        return true;
+    }
+
+    public FileInfo GetFileInfo(string path)
+    {
+        throw new NotImplementedException();
+    }
+
+    public FileInfo[] GetFiles(string path, string searchPattern, SearchOption searchOption)
+    {
+        throw new NotImplementedException();
+    }
+
+    public bool ParentDirectoryExists(string path)
+    {
+        throw new NotImplementedException();
+    }
+
+    public string[] ReadAllLines(string path)
+    {
+        throw new NotImplementedException();
+    }
+
+    public string ReadAllText(string path)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void WriteAllText(string path, string data)
+    {
+        throw new NotImplementedException();
+    }
+}
+
+public class FailingFileManager : IFileManager
+{
+    public void CreateParentDirectory(string path)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void DeleteFile(string path)
+    {
+        throw new NotImplementedException();
+    }
+
+    public bool FileExists(string path)
+    {
+        return false;
+    }
+
+    public FileInfo GetFileInfo(string path)
+    {
+        throw new NotImplementedException();
+    }
+
+    public FileInfo[] GetFiles(string path, string searchPattern, SearchOption searchOption)
+    {
+        throw new NotImplementedException();
+    }
+
+    public bool ParentDirectoryExists(string path)
+    {
+        throw new NotImplementedException();
+    }
+
+    public string[] ReadAllLines(string path)
+    {
+        throw new NotImplementedException();
+    }
+
+    public string ReadAllText(string path)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void WriteAllText(string path, string data)
+    {
+        throw new NotImplementedException();
     }
 }


### PR DESCRIPTION
Decouple Environment class from the ServiceContainer extension method which validates that do.json is present.

There is more debt here as the constructor for the environment class shouldn't really be doing anything, but is better than it was.

Evidence:

Pipeline run: https://github.com/andy192700/psdoframework/actions/runs/12996687909

Local build:
![image](https://github.com/user-attachments/assets/29dbf227-cd45-4582-8bee-e56ebf3806d7)

![image](https://github.com/user-attachments/assets/d1ca0903-2620-4b50-a9f8-034ee9c028e4)

![image](https://github.com/user-attachments/assets/2bf59f7d-0848-42c5-8212-f22bbfad8dd3)

![image](https://github.com/user-attachments/assets/0ad2f268-3a46-4a4a-b43e-ee37d89247e5)

![image](https://github.com/user-attachments/assets/958498f6-b982-4207-849c-c52edbf06daf)

![image](https://github.com/user-attachments/assets/24e48264-8483-44af-89e3-ddec18de22dc)
